### PR TITLE
Set footer copyright year dynamically

### DIFF
--- a/src/layout/Footer.tsx
+++ b/src/layout/Footer.tsx
@@ -155,7 +155,7 @@ const Footer = () => {
                         <Text>{content.businessAddress1}</Text>
                         <Text>{content.businessAddress2}</Text>
                     </Box>
-                    <Text fontSize={['md', 'md']}>&copy; Focus 2025. All rights reserved.</Text>
+                    <Text fontSize={['md', 'md']}>&copy; Focus {(new Date()).getFullYear()}. All rights reserved.</Text>
                 </Box>                
             )
         }


### PR DESCRIPTION
Tested by building and running the Gatsby site locally (`yarn run build && yarn run serve`).

Before | After
--- | ---
<img width="299" height="171" alt="image" src="https://github.com/user-attachments/assets/60317cce-d14f-4853-8b2f-973dc812087b" /> | <img width="297" height="173" alt="image" src="https://github.com/user-attachments/assets/de15ac81-baf5-40d4-abd7-cb3db043441b" />
